### PR TITLE
Add mods per version in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,42 +1,58 @@
-name: Create zip asset, push it in release and archive it when a new tag is created
+name: Release
 
+permissions:
+  contents: write
 on:
   push:
     tags:
       - 'v*'
-
 jobs:
-  zip:
+
+  compress_and_push_mods_versionned_assets:
+    name: "[${{ matrix.compress_format }}] Compress ${{ matrix.mod_version }}"
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    strategy:
+      matrix:
+        mod_version: ['1.0.0', '1.1.0', '1.1.1', '1.1.2']
+        compress_format: ['zip', '7z']
     steps:
-      - name: Checkout the code
+      - name: Checkout code
         uses: actions/checkout@v3
-      - name: zip mods
-        run: 7z a -tzip -mx9 ./Releases/TOTK-Mods-collection_${{ github.ref_name }}.zip -x!'./.git/' -x!'./Releases/' -x!'./.github/' -x!'./config.yaml' ./
-      - name: 7z mods
-        run: 7z a -t7z -mx9 ./Releases/TOTK-Mods-collection_${{ github.ref_name }}.7z -x!'./.git/' -x!'./Releases/' -x!'./.github/' -x!'./config.yaml' ./
-      - name: Push the zip of assets
-        uses: softprops/action-gh-release@v1
-        with:
-          files: Releases/TOTK-Mods-collection_${{ github.ref_name }}.zip # This only works if your workflow triggers on new tags
-      - name: Push the 7zip of assets
-        uses: softprops/action-gh-release@v1
-        with:
-          files: Releases/TOTK-Mods-collection_${{ github.ref_name }}.7z # This only works if your workflow triggers on new tags
-      - name: Switching from HTTPS to SSH
-        run: git remote set-url origin ${{ secrets.ssh_url }}
-      - name: Check for changes
-        run: git status
-      - name: Stage changed files
+      - name: Set up zip
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add Releases/
-          git commit -a -m "Pushing new release ${{ github.ref_name }}"
-      - name: Push changes on main ✨
-        uses: ad-m/github-push-action@master
+          sudo chmod +x zip_script.sh
+          ./zip_script.sh ${{ matrix.mod_version }} ${{ matrix.compress_format }} TOTK-Mods-collection_${{ github.ref_name }}_for-${{ matrix.mod_version }}.${{ matrix.compress_format }}
+      - name: Push the assets
+        uses: softprops/action-gh-release@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: main
+          files: TOTK-Mods-collection_${{ github.ref_name }}_for-${{ matrix.mod_version }}.${{ matrix.compress_format }}
+
+  compress_and_push_mods_assets:
+    name: "[zip, 7z] Compress all versions"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Compress mods to folder Releases
+      run:  |
+        7z a -tzip -mx9 ./Releases/TOTK-Mods-collection_${{ github.ref_name }}.zip -x!'./.git/' -x!'./Releases/' -x!'./.github/' -x!'./config.yaml' ./
+        7z a -t7z -mx9 ./Releases/TOTK-Mods-collection_${{ github.ref_name }}.7z -x!'./.git/' -x!'./Releases/' -x!'./.github/' -x!'./config.yaml' ./
+    - name: Push the assets on Tag/Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          Releases/TOTK-Mods-collection_${{ github.ref_name }}.zip
+          Releases/TOTK-Mods-collection_${{ github.ref_name }}.7z
+    - name: Checkout on main before pushing changes
+      uses: actions/checkout@v3
+      with:
+        ref: main
+        clean: false
+    - name: Push new releases on main
+      run: |
+        git status
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add Releases/
+        git commit -a -m "Pushing new release ${{ github.ref_name }}"
+        git push

--- a/zip_script.sh
+++ b/zip_script.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+version="$1"
+format="$2"
+zip_file="$3"
+
+# Create a temporary directory to store the compatible config files
+temp_dir=$(mktemp -d)
+
+# Find folders containing config.yaml within the Mods directory and its subdirectories
+IFS=$'\n' # Set the IFS (Internal Field Separator) to handle folder names with spaces
+folders=($(find . -type f -name "config.yaml" -exec dirname {} \;))
+
+# Iterate through the folders
+for folder in "${folders[@]}"; do
+  # Read the game versions using yq and store them in an array using mapfile
+  result=$(yq e ".game.version[] | select(. == \"$version\")" "$folder/config.yaml")
+  if [[ -n $result ]]; then
+    # Copy the folder to the temporary directory
+    mkdir -p "$temp_dir/$folder" && cp -r "$folder" "$temp_dir/$folder/../"
+  fi
+done
+
+# Create a zip file containing the compatible folders
+7z a -t"$format" -mx9 "$zip_file" "$temp_dir/*"
+7z a -t"$format" -mx9 "$zip_file" "README.md"
+7z a -t"$format" -mx9 "$zip_file" "LICENSE"
+7z a -t"$format" -mx9 "$zip_file" "Guide"
+
+# Clean up the temporary directory
+rm -rf "$temp_dir"
+
+echo "Zip file created: $zip_file"


### PR DESCRIPTION
For the release I made on my repo, v11.0.1 we can see all assets distributed with 7z and zip.

![image](https://github.com/HolographicWings/TOTK-Mods-collection/assets/17164385/76b51963-a058-4af9-81eb-1525abd8f5d7)

They are all with valid sizes and optimised. Archives in Releases/ are still pushed.

![image](https://github.com/HolographicWings/TOTK-Mods-collection/assets/17164385/3f9aac86-788a-4f54-a2f7-41ace2f12a9e)
