### PR TITLE
Correct Lazy Pack Title

### DIFF
--- a/Mods/Lazy Packs/60 FPS - 1440p 2X - 2880p 4X - UI Mod Compatible/config.yaml
+++ b/Mods/Lazy Packs/60 FPS - 1440p 2X - 2880p 4X - UI Mod Compatible/config.yaml
@@ -1,5 +1,5 @@
 id: cd7304b6-b01a-428c-9b44-8dbbe0b047b3
-title: Lazy Pack - 30 FPS - 1440p 2X - 2880p 4X - UI Mod Compatible
+title: Lazy Pack - 60 FPS - 1440p 2X - 2880p 4X - UI Mod Compatible
 subtitle: 'it just werks'
 description: Combination of over a dozen patches. Compatible with most mods. Use UI Mod Compatible version if you want to use a controller mod such as Playstation UI.
 version: 3


### PR DESCRIPTION
This 60 fps lazy pack has "30 fps" in its config titles. This fixes that.